### PR TITLE
Change localhost to 0.0.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ var utils = require('./utils');
 
 var server = new Hapi.Server();
 server.connection({
-  host: 'localhost',
+  host: '0.0.0.0',
   port: process.env.PORT || 8000
 });
 


### PR DESCRIPTION
Heroku needs this to bind to the correct address, as `localhost` won't cut it.

This instructs Hapi to listen on all IPs that the server has, which should take care of getting the app listening on Heroku.
